### PR TITLE
support configuration

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -34,7 +34,9 @@ function activate(context) {
         terminal.sendText(
           `typora "${vscode.window.activeTextEditor.document.fileName}"`
         );
-        vscode.window.showInformationMessage("Starting Typora");
+        if (vscode.workspace.getConfiguration("openInTypora").get("showSuccessInformationMessage")) {
+          vscode.window.showInformationMessage("Starting Typora");
+        }
       } catch (e) {
         vscode.window.showInformationMessage(
           `Failed to open file: ${vscode.window.activeTextEditor.document.fileName} in Typora!`
@@ -48,23 +50,23 @@ function activate(context) {
 
   const bar = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right);
   bar.text = "$(book) Typora";
-  bar.tooltip = "Open current markdown file in Typora";
+  bar.tooltip = "Open in Typora";
   bar.command = "typora.open";
-  if (vscode.window.activeTextEditor.document.languageId == "markdown") {
-    bar.show();
-  } else {
-    bar.hide();
-  }
+  showStatusBar(vscode.window.activeTextEditor.document.languageId);
   statusBarArray.push(bar);
   context.subscriptions.push(bar);
 
   context.subscriptions.push(vscode.window.onDidChangeActiveTextEditor((e) => {
-    if (e.document.languageId == "markdown") {
+    showStatusBar(e.document.languageId);
+  }))
+
+  function showStatusBar(languageId, showStatusBarConfig) {
+    if (languageId == "markdown" && vscode.workspace.getConfiguration("openInTypora").get("showStatusBar")) {
       bar.show();
     } else {
       bar.hide();
     }
-  }))
+  }
 }
 
 function clear() {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,33 @@
   ],
   "main": "./extension.js",
   "contributes": {
+    "configuration":[
+      {
+        "title": "Open In Typora",
+        "properties": {
+          "openInTypora.showSuccessInformationMessage": {
+            "type": "boolean",
+            "default": false,
+            "description": "Show information message on success"
+          },
+          "openInTypora.showStatusBar": {
+            "type": "boolean",
+            "default": true,
+            "description": "Show status bar"
+          },
+          "openInTypora.showContextMenuInEditor": {
+            "type": "boolean",
+            "default": true,
+            "description": "Show context menu in editor"
+          },
+          "openInTypora.showContextMenuInExplorer": {
+            "type": "boolean",
+            "default": true,
+            "description": "Show context menu in explorer"
+          }
+        }
+      }
+    ],
     "commands": [
       {
         "command": "typora.open",
@@ -41,14 +68,14 @@
         {
           "command": "typora.open",
           "group": "navigation",
-          "when": "editorLangId == markdown"
+          "when": "editorLangId == markdown && config.openInTypora.showContextMenuInEditor"
         }
       ],
       "explorer/context": [
         {
           "command": "typora.open",
           "group": "navigation",
-          "when": "resourceLangId == markdown"
+          "when": "resourceLangId == markdown && config.openInTypora.showContextMenuInExplorer"
         }
       ]
     }


### PR DESCRIPTION
#8 

By default, the infomation message on success is no longer displayed, and several configurations are provided to control the display: infomation message/context menus/status bar button

![image](https://user-images.githubusercontent.com/39125296/104751185-01151c80-5790-11eb-8ae0-f13f81a026f2.png)
